### PR TITLE
Added op3_walking_module_msgs in find_package() function

### DIFF
--- a/op3_walking_module/CMakeLists.txt
+++ b/op3_walking_module/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   dynamixel_sdk
   eigen_conversions
   op3_kinematics_dynamics
+  op3_walking_module_msgs
   robotis_controller_msgs
   robotis_device
   robotis_framework_common


### PR DESCRIPTION
Added op3_walking_module_msgs in find_package() function to be built. 

Without this, catkin can not find op3_walking_module_msgs/WalkingParam.h file and the other header files.